### PR TITLE
* Free bootstrap version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "prefer-stable": true,
     "require": {
         "yiisoft/yii2": "*",
-        "yiisoft/yii2-bootstrap": "~2.0.0",
+        "yiisoft/yii2-bootstrap": "*",
         "bower-asset/bootbox": "~4.4.0"
     },
     "autoload": {


### PR DESCRIPTION
Don't fix yii2-bootstrap, so it can be used with the upcoming bootstrap4 (branch 2.1) version
